### PR TITLE
Fix definition of Crefname to gain "Abb." instead of "ABB."

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -373,8 +373,11 @@
      \usepackage[ngerman,nameinlink]{cleveref}
    \fi%
    \crefname{figure}{\figurename}{\figurename}
+   \Crefname{figure}{\figurename}{\figurename}
    \crefname{listing}{\lstlistingname}{\lstlistingname}
+   \Crefname{listing}{\lstlistingname}{\lstlistingname}
    \crefname{table}{\tablename}{\tablename}
+   \Crefname{table}{\tablename}{\tablename}
 \fi%
 \RequirePackage[all]{hypcap}
 \def\and{\unskip\hspace{-0.42em},\hspace{.6em}}

--- a/lni.dtx
+++ b/lni.dtx
@@ -1100,8 +1100,11 @@ This work consists of the file  lni.dtx
      \usepackage[ngerman,nameinlink]{cleveref}
    \fi%
    \crefname{figure}{\figurename}{\figurename}
+   \Crefname{figure}{\figurename}{\figurename}
    \crefname{listing}{\lstlistingname}{\lstlistingname}
+   \Crefname{listing}{\lstlistingname}{\lstlistingname}
    \crefname{table}{\tablename}{\tablename}
+   \Crefname{table}{\tablename}{\tablename}
 \fi%
 %    \end{macrocode}
 % enables correct jumping to figures when referencing


### PR DESCRIPTION
When `Crefname` is undefined, cleveref uses `MakeUppercase`, which uppercases *all* letters. This is an undesired effect. This patch fixes it, so that, for instance, "Abb." and "Fig." are used when referencing a figure in German/English documents using `\Cref{...}`.