### PR TITLE
Add support to output DOI

### DIFF
--- a/lni-author-template.tex
+++ b/lni-author-template.tex
@@ -25,6 +25,7 @@ Firstname2 Lastname2\footnote{University, Department, Address, Country
 \editor{Herausgeber et al.} % Names of Editors
 \booktitle{Name-der-Konferenz} % Name of book title
 \year{2017}
+\lnidoi{18.18420/provided-by-editor-02} % if known
 \maketitle
 
 \begin{abstract}

--- a/lni.cls
+++ b/lni.cls
@@ -97,6 +97,10 @@
   <12->   MnSymbolC12%
 }{}
 \DeclareMathSymbol{\powerset}{\mathord}{MnSyC}{180}
+\RequirePackage{ccicons}
+\RequirePackage{etoolbox}
+\newlength{\doihoffset}
+\newlength{\doivoffset}
 \ifcrop
    \RequirePackage[
      paperheight=23.5cm,paperwidth=15.5cm,
@@ -137,6 +141,8 @@
          \hss
       }%
    }}%
+   \setlength{\doihoffset}{1.45cm}
+   \setlength{\doivoffset}{1.2cm}
 \else
    \RequirePackage[
      total={12.6cm,19.2cm},
@@ -145,6 +151,8 @@
      headsep=.31cm,
      centering]
      {geometry}
+   \setlength{\doihoffset}{4.2cm}
+   \setlength{\doivoffset}{4.3cm}
 \fi%
 \RequirePackage[autostyle]{csquotes}
 \ifusebiblatex
@@ -167,6 +175,7 @@
     {\usebibmacro{postnote}}%
 \fi%
 \RequirePackage{graphicx}
+\RequirePackage{eso-pic}
 \RequirePackage{grffile}
 \RequirePackage{fancyhdr}
 \RequirePackage{listings}
@@ -202,6 +211,8 @@
 \newcommand{\authorrunning}[1]{%
    \fancyhead[LE]{\hspace{0.05cm}\small\thepage\hspace{5pt}#1}}
 \newcommand*{\email}[1]{{\urlstyle{same}\protect\url{#1}}}
+\newcommand{\@lnidoi}{}
+\newcommand{\lnidoi}[1]{\gdef\@lnidoi{#1}}
 \renewcommand\maketitle{\par%
 \begingroup
     \renewcommand\thefootnote{\@arabic\c@footnote}%
@@ -259,6 +270,23 @@
       \par}%
     \vskip 28pt% Abstand vor dem Abstract
   \end{center}%
+  \AddToShipoutPictureBG*{\AtPageLowerLeft{%
+    \put(\LenToUnit{\the\doihoffset},\LenToUnit{\the\doivoffset}){%
+      \ifusehyperref
+        \href{https://creativecommons.org/licenses/by-nc/3.0/}{\ccbynceu}
+      \else
+        \ccbynceu
+      \fi
+      \ifdefempty{\@lnidoi}{}{
+        \footnotesize
+        \ifusehyperref
+          \href{https://doi.org/\@lnidoi}{doi:\@lnidoi}
+        \else
+          doi:\lnidoi
+        \fi
+      }
+    }
+  }}
   \par
 }%
 \renewenvironment*{abstract}{%

--- a/lni.dtx
+++ b/lni.dtx
@@ -245,7 +245,8 @@ This work consists of the file  lni.dtx
  language     = [LaTeX]{TeX},
  moretexcs    = {,
    addbibresource,authorrunning,%
-   email,ExecuteBibliographyOptions,includegraphics,printbibliography,
+   email,lnidoi,
+   ExecuteBibliographyOptions,includegraphics,printbibliography,
  }
  frame        = single,
  backgroundcolor = \color{yellow!60},
@@ -464,6 +465,13 @@ This work consists of the file  lni.dtx
 % \end{examplecode}
 % In case the authors are too long for the page header, see 
 % \cref{sec:pageheader} of how to shorten the authors for the page header.
+%
+% \DescribeMacro{\lnidoi\space(new in v1.2)}%
+% LNI provides a DOI for each paper. In case, the DOI is known, it can be
+% specified using the \cs{lnidoi} macro.
+% \begin{examplecode}[label={lst:lnidoi}]
+% \lnidoi{18.18420/se2016}
+% \end{examplecode}
 %
 % Finally \cs{maketitle} will output the formatted title page.
 %
@@ -756,8 +764,14 @@ This work consists of the file  lni.dtx
 }{}
 \DeclareMathSymbol{\powerset}{\mathord}{MnSyC}{180}
 %    \end{macrocode}
+% Support for CC icons
+\RequirePackage{ccicons}
+% Support for \ifdefempty
+\RequirePackage{etoolbox}
 % Satzspiegel
 %    \begin{macrocode}
+\newlength{\doihoffset}
+\newlength{\doivoffset}
 \ifcrop
    \RequirePackage[
      paperheight=23.5cm,paperwidth=15.5cm,
@@ -798,6 +812,8 @@ This work consists of the file  lni.dtx
          \hss
       }%
    }}%
+   \setlength{\doihoffset}{1.45cm}
+   \setlength{\doivoffset}{1.2cm}
 \else
    \RequirePackage[
      total={12.6cm,19.2cm},
@@ -806,6 +822,8 @@ This work consists of the file  lni.dtx
      headsep=.31cm,
      centering]
      {geometry}
+   \setlength{\doihoffset}{4.2cm}
+   \setlength{\doivoffset}{4.3cm}
 \fi%
 %    \end{macrocode}
 %    \begin{macrocode}
@@ -837,6 +855,7 @@ This work consists of the file  lni.dtx
 %    \end{macrocode}
 %    \begin{macrocode}
 \RequirePackage{graphicx}
+\RequirePackage{eso-pic}
 \RequirePackage{grffile}
 \RequirePackage{fancyhdr}
 \RequirePackage{listings}
@@ -900,6 +919,12 @@ This work consists of the file  lni.dtx
 \newcommand*{\email}[1]{{\urlstyle{same}\protect\url{#1}}}
 %    \end{macrocode}
 % \end{macro}
+% \begin{macro}{\lnidoi}
+%    \begin{macrocode}
+\newcommand{\@lnidoi}{}
+\newcommand{\lnidoi}[1]{\gdef\@lnidoi{#1}}
+%    \end{macrocode}
+% \end{macro}
 % Title: Kopie aus article.cls mit anderem \thispagestyle
 %    \begin{macrocode}
 \renewcommand\maketitle{\par%
@@ -961,6 +986,24 @@ This work consists of the file  lni.dtx
       \par}%
     \vskip 28pt% Abstand vor dem Abstract
   \end{center}%
+% output CC license and DOI (if it exists)
+  \AddToShipoutPictureBG*{\AtPageLowerLeft{%
+    \put(\LenToUnit{\the\doihoffset},\LenToUnit{\the\doivoffset}){%
+      \ifusehyperref
+        \href{https://creativecommons.org/licenses/by-nc/3.0/}{\ccbynceu}
+      \else
+        \ccbynceu
+      \fi
+      \ifdefempty{\@lnidoi}{}{
+        \footnotesize
+        \ifusehyperref
+          \href{https://doi.org/\@lnidoi}{doi:\@lnidoi}
+        \else
+          doi:\lnidoi
+        \fi
+      }
+    }
+  }}
   \par
 }%
 %    \end{macrocode}
@@ -2702,6 +2745,7 @@ Firstname2 Lastname2\footnote{University, Department, Address, Country
 \editor{Herausgeber et al.} % Names of Editors
 \booktitle{Name-der-Konferenz} % Name of book title
 \year{2017}
+%%%\lnidoi{18.18420/provided-by-editor-02} % if known
 \maketitle
 
 \begin{abstract}


### PR DESCRIPTION
To be in line with the proceedings generation, this PR adds support for DOIs.

DOI support is new - see the "Herausgeberrichtlinien" at https://www.gi.de/service/publikationen/lni/autorenrichtlinien.html.

![grafik](https://cloud.githubusercontent.com/assets/1366654/25568344/fa48d43a-2e00-11e7-9c95-05eb66130421.png)
