### PR TITLE
Change texgyretermes font inclusion

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -97,7 +97,14 @@
    \else
       \usepackage{newtxmath}
       \usepackage[no-math]{fontspec}
-      \setmainfont[Ligatures=TeX]{TeXGyreTermesX}
+      \setmainfont{texgyretermes}[
+        Extension = .otf,
+        UprightFont = *-regular,
+        BoldFont = *-bold,
+        ItalicFont = *-italic,
+        BoldItalicFont = *-bolditalic,
+        Ligatures=TeX
+      ]
    \fi%
 \fi%
 \ifPDFTeX

--- a/lni.dtx
+++ b/lni.dtx
@@ -778,7 +778,14 @@ This work consists of the file  lni.dtx
    \else
       \usepackage{newtxmath}
       \usepackage[no-math]{fontspec}
-      \setmainfont[Ligatures=TeX]{TeXGyreTermesX}
+      \setmainfont{texgyretermes}[
+        Extension = .otf,
+        UprightFont = *-regular,
+        BoldFont = *-bold,
+        ItalicFont = *-italic,
+        BoldItalicFont = *-bolditalic,
+        Ligatures=TeX
+      ]
    \fi%
 \fi%
 %    \begin{macrocode}


### PR DESCRIPTION
At least on debian stable the font has to be included like this. I could not find any example using `TeXGyreTermesX` with fontspec.