### PR TITLE
Fix output

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -126,14 +126,16 @@
 \fi%
 \ifoldfonts
    \RequirePackage{mathptmx}
-\else% nofonts activated
-   \ClassWarning{lni}{Option `nofonts' set! I will use standard fonts
-   \MessageBreak
-   instead of the New TX fonts. Your document will NOT look like the
-   \MessageBreak
-   final result for publication. This should only be used if you have
-   \MessageBreak
-   no possibility to install fonts or upgrade your TeX installation!}%
+\else%
+   \ifnofonts % nofonts activated
+      \ClassWarning{lni}{Option `nofonts' set! I will use standard fonts
+      \MessageBreak
+      instead of the New TX fonts. Your document will NOT look like the
+      \MessageBreak
+      final result for publication. This should only be used if you have
+      \MessageBreak
+      no possibility to install fonts or upgrade your TeX installation!}%
+   \fi%
 \fi%
 \ifPDFTeX
    \RequirePackage[%

--- a/lni.dtx
+++ b/lni.dtx
@@ -804,14 +804,16 @@ This work consists of the file  lni.dtx
 \fi%         
 \ifoldfonts
    \RequirePackage{mathptmx}
-\else% nofonts activated
-   \ClassWarning{lni}{Option `nofonts' set! I will use standard fonts
-   \MessageBreak
-   instead of the New TX fonts. Your document will NOT look like the
-   \MessageBreak
-   final result for publication. This should only be used if you have
-   \MessageBreak
-   no possibility to install fonts or upgrade your TeX installation!}%
+\else%
+   \ifnofonts % nofonts activated
+      \ClassWarning{lni}{Option `nofonts' set! I will use standard fonts
+      \MessageBreak
+      instead of the New TX fonts. Your document will NOT look like the
+      \MessageBreak
+      final result for publication. This should only be used if you have
+      \MessageBreak
+      no possibility to install fonts or upgrade your TeX installation!}%
+   \fi%
 \fi%
 %    \begin{macrocode}
 \ifPDFTeX


### PR DESCRIPTION
In case `autofonts` was used, the class complained about using `nofonts`. This fixes this.

```
Class lni Warning: Option `nofonts' set! I will use standard fonts 
(lni)              instead of the New TX fonts. Your document will NOT look lik
e the 
(lni)              final result for publication. This should only be used if yo
u have 
(lni)              no possibility to install fonts or upgrade your TeX installa
tion! on input line 136.
```

The output of the version before is available at https://circleci.com/gh/gi-ev/LNI/6