### PR TITLE
Fix basewidth for lstlistings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New option `oldfonts` to use the class file on older systems by loading the `mathptmx` font package ([#56](https://github.com/gi-ev/LNI/issues/56))
 - New macros added (taken from `emisa.dtx`) ([#57](https://github.com/gi-ev/LNI/issues/57))
 - Hint to word limit for abstract ([#60](https://github.com/gi-ev/LNI/issues/60))
+- Fix basewidth for lstlistings
 
 ### Changed
 - Package `caption` is loaded in order to make the class more robust ([#59](https://github.com/gi-ev/LNI/issues/59))

--- a/lni.cls
+++ b/lni.cls
@@ -255,6 +255,10 @@
 \RequirePackage{grffile}
 \RequirePackage{fancyhdr}
 \RequirePackage{listings}
+% Fix basewidth for lstlistings:
+% "The default setting of listings with "fixed columns" has a space 0.6em wide, while the characters in Computer Modern Typewriter are 0.5em wide"
+% Source: https://tex.stackexchange.com/a/179072/9075
+\lstset{basicstyle=\ttfamily, columns=fixed, basewidth=.5em, xleftmargin=0.5cm, captionpos=b}
 \def\thisbottomragged{\def\@textbottom{\vskip\z@ plus.0001fil
 \global\let\@textbottom\relax}}
 \renewcommand\@pnumwidth{3em}


### PR DESCRIPTION
The default setting of listings with "fixed columns" has a space 0.6em wide, while the characters in Computer Modern Typewriter are 0.5em wide. Source: https://tex.stackexchange.com/a/179072/9075

This PR fixes the basewidth value