### PR TITLE
Disable PDF bookmarks as intended in lni.cls code

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -504,10 +504,9 @@
 \g@addto@macro{\UrlBreaks}{\UrlOrds}
 \RequirePackage{xspace}
 \ifusehyperref
-   \RequirePackage[pdfusetitle]{hyperref}
+   \RequirePackage[pdfusetitle,bookmarks=false]{hyperref}
    \hypersetup{%
       pdfdisplaydoctitle,
-      bookmarks=false,%
       colorlinks=true,%
       allcolors=black,%
       %%%pdfpagelayout=TwoPageRight,%


### PR DESCRIPTION
This PR considers the hyperref warning `Option 'bookmarks' has already been used, setting the option has no effect on input line xx`. I assume that the intention of L510 `bookmarks=false,` is to disable the PDF _Bookmarks_ and _Contents_ bars for all LNI works.

Option `bookmarks` can not be set inside `\hypersetup{}` and must be used in package options. Therefore, I move its declaration in `lni.cls` to the `\RequirePackage{hyperref}`.

See also https://latex.org/forum/viewtopic.php?t=15186, which I could verify in my own project (tested with Okular).