### PR TITLE
Fix typo in check for TeX Gyre Termes font.

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -110,7 +110,7 @@
          {\RequirePackage{newtxmath}}%
          {}%
       \RequirePackage[no-math]{fontspec}
-      \IfFontExistsTF{texgyretrmes-regular.otf}
+      \IfFontExistsTF{texgyretermes-regular.otf}
          {%
           \setmainfont{texgyretermes}[
              Extension = .otf,

--- a/lni.dtx
+++ b/lni.dtx
@@ -848,7 +848,7 @@ This work consists of the file  lni.dtx
          {\RequirePackage{newtxmath}}%
          {}%
       \RequirePackage[no-math]{fontspec}
-      \IfFontExistsTF{texgyretrmes-regular.otf}
+      \IfFontExistsTF{texgyretermes-regular.otf}
          {%
           \setmainfont{texgyretermes}[
              Extension = .otf,


### PR DESCRIPTION
The font name was “texgyretrmes-regular.otf” rather than
“texgyretermes-regular.otf”.  This lead to the obscure error message

  Invalid filename `[texgyretrmes-regular', contains '['