### PR TITLE
Fix #107: Use hook to make biblatex aware of hyperref

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -561,7 +561,7 @@
 \g@addto@macro{\UrlBreaks}{\UrlOrds}
 \RequirePackage{xspace}
 \ifusehyperref
-   \AtEndPreamble{%
+   \AddToHook{env/document/begin}[cid/loadhyp]{
       \RequirePackage[bookmarks=false]{hyperref}
       \hypersetup{%
          pdfdisplaydoctitle,%
@@ -569,11 +569,8 @@
          allcolors=black,%
          pdfstartview=Fit,%
       }%
-%%%      \pdfstringdefDisableCommands{%
-%%%         \def\unskip{}%
-%%%         \renewcommand{\footnote}[1]{}%
-%%%      }%
    }%
+   \DeclareHookRule{env/document/begin}{cid/loadhyp}{before}{biblatex}
 \else
    \providecommand{\texorpdfstring}[2]{#2}%
 \fi%

--- a/lni.dtx
+++ b/lni.dtx
@@ -1476,7 +1476,7 @@ This work consists of the file  lni.dtx
 %    \end{macrocode}
 %    \begin{macrocode}
 \ifusehyperref
-   \AtEndPreamble{%
+   \AddToHook{env/document/begin}[cid/loadhyp]{
       \RequirePackage[bookmarks=false]{hyperref}
       \hypersetup{%
          pdfdisplaydoctitle,%
@@ -1484,11 +1484,8 @@ This work consists of the file  lni.dtx
          allcolors=black,%
          pdfstartview=Fit,%
       }%
-%%%      \pdfstringdefDisableCommands{%
-%%%         \def\unskip{}%
-%%%         \renewcommand{\footnote}[1]{}%
-%%%      }%
    }%
+   \DeclareHookRule{env/document/begin}{cid/loadhyp}{before}{biblatex}
 \else
    \providecommand{\texorpdfstring}[2]{#2}%
 \fi%


### PR DESCRIPTION
Use hook to make biblatex aware of hyperref