### PR TITLE
Add CHANGELOG.md linter

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,3 +89,15 @@ jobs:
         with:
           name: CTAN-${{ matrix.engine }}
           path: '*.tar.gz'
+  changelog:
+    name: CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          show-progress: ''
+      - uses: jbangdev/jbang-action@v0.110.1
+        with:
+          script: com.github.nbbrd.heylogs:heylogs-cli:0.7.2:bin
+          scriptargs: "check CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
@@ -97,7 +97,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- New option `nofonts` to use the class file on older systems ([#53](https://github.com/gi-ev/LNI/issues/52))
+- New option `nofonts` to use the class file on older systems ([#53](https://github.com/gi-ev/LNI/issues/53))
 
 ### Changed
 


### PR DESCRIPTION
We have issues in our CHANGELOG:

```errors
CHANGELOG.md
    4:24  error  Expecting HTTPS protocol                 https
  100:64  error  Expecting GitHub issue ref 52, found 53  github-issue-ref
```

This PR fixes them - and adds [heylogs](https://github.com/nbbrd/heylogs#heylogs) as linter.