### PR TITLE
Add \vfill to definition of \footnoterule to keep footnotes at the bottom

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -481,7 +481,7 @@
 \RequirePackage{verbatim}
 \def\verbatim@processline{\hskip0.5cm\the\verbatim@line\par}
 \renewcommand\footnoterule{%
-  \kern-3\p@
+  \vfill\kern-3\p@
   \hrule\@width 5cm
   \kern2.6\p@}
 \newdimen\fnindent

--- a/lni.dtx
+++ b/lni.dtx
@@ -1352,7 +1352,7 @@ This work consists of the file  lni.dtx
 % Set rule width und correct size
 %    \begin{macrocode}
 \renewcommand\footnoterule{%
-  \kern-3\p@
+  \vfill\kern-3\p@
   \hrule\@width 5cm
   \kern2.6\p@}
 \newdimen\fnindent


### PR DESCRIPTION
Add `\vfill` to definition of `\footnoterule` to keep footnotes at the bottom