### PR TITLE
Fix #87: Suppress \footnote from pdf bookmarks

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -264,6 +264,7 @@
     {\multicitedelim}%
     {\usebibmacro{postnote}}%
 \fi%
+\RequirePackage{etoolbox}
 \RequirePackage{graphicx}
 \RequirePackage{eso-pic}
 \RequirePackage{grffile}
@@ -300,7 +301,8 @@
      \par}%
   \fi}
 \renewcommand{\title}{\@dblarg\@@title}
-\def\@@title[#1]#2{\gdef\@shorttitle{#1}\gdef\@title{#2}}
+\def\@@title[#1]#2{%
+   \gdef\@shorttitle{#1}\gdef\@title{#2}}
 \newcommand{\subtitle}[1]{\gdef\@subtitle{#1}}
 \renewcommand{\author}{\@dblarg\@@author}
 \newcommand{\@@author}[2][]{%
@@ -480,6 +482,7 @@
 \setlength{\mathindent}{0.5cm}
 \RequirePackage{verbatim}
 \def\verbatim@processline{\hskip0.5cm\the\verbatim@line\par}
+\robustify{\footnote}
 \renewcommand\footnoterule{%
   \vfill\kern-3\p@
   \hrule\@width 5cm
@@ -569,6 +572,9 @@
          allcolors=black,%
          pdfstartview=Fit,%
       }%
+      \pdfstringdefDisableCommands{%
+         \def\footnote#1{}%
+      }
    }%
    \DeclareHookRule{env/document/begin}{cid/loadhyp}{before}{biblatex}
 \else

--- a/lni.dtx
+++ b/lni.dtx
@@ -1062,6 +1062,7 @@ This work consists of the file  lni.dtx
 \fi%
 %    \end{macrocode}
 %    \begin{macrocode}
+\RequirePackage{etoolbox}
 \RequirePackage{graphicx}
 \RequirePackage{eso-pic}
 \RequirePackage{grffile}
@@ -1115,7 +1116,8 @@ This work consists of the file  lni.dtx
 % \begin{macro}{\title}
 %    \begin{macrocode}
 \renewcommand{\title}{\@dblarg\@@title}
-\def\@@title[#1]#2{\gdef\@shorttitle{#1}\gdef\@title{#2}}
+\def\@@title[#1]#2{%
+   \gdef\@shorttitle{#1}\gdef\@title{#2}}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\subtitle}
@@ -1349,6 +1351,9 @@ This work consists of the file  lni.dtx
 \RequirePackage{verbatim}
 \def\verbatim@processline{\hskip0.5cm\the\verbatim@line\par}
 %    \end{macrocode}
+%    \begin{macrocode}
+\robustify{\footnote}
+%    \end{macrocode}
 % Set rule width und correct size
 %    \begin{macrocode}
 \renewcommand\footnoterule{%
@@ -1484,6 +1489,9 @@ This work consists of the file  lni.dtx
          allcolors=black,%
          pdfstartview=Fit,%
       }%
+      \pdfstringdefDisableCommands{%
+         \def\footnote#1{}%
+      }
    }%
    \DeclareHookRule{env/document/begin}{cid/loadhyp}{before}{biblatex}
 \else


### PR DESCRIPTION
`\footnote` should not be integrated into the pdf bookmarks for `\author` and `\title`.
