### PR TITLE
No running heads as default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,7 @@ jobs:
            package_file: Texlivefile
       - name: Generate lni.cls, *.tex, ...
         run: |
+          pdflatex lni.ins
           pdflatex lni.dtx
           pdflatex lni.dtx
           pdflatex lni.dtx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Added option `anonymous` for anonymizing an article ([#100](https://github.com/gi-ev/LNI/pull/100))
 - Added `\pdfoutput=1` to fix compatibility with [arXiv](https://arxiv.org/) ([#81](https://github.com/gi-ev/LNI/issues/81))
+- Added option `runningheads` to enable running heads
 
 ### Changed
 
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Add more links to `biblatex-lni` to documentation ([#90](https://github.com/gi-ev/LNI/issues/90))
 - Add `\yearofpublication` to documentation ([#89](https://github.com/gi-ev/LNI/pull/89))
 - Improvement for documentation ([#89](https://github.com/gi-ev/LNI/issues/89), [#90](https://github.com/gi-ev/LNI/issues/90), [#93](https://github.com/gi-ev/LNI/issues/93), [#95](https://github.com/gi-ev/LNI/issues/95), [#96](https://github.com/gi-ev/LNI/issues/96))
+- Headings are not shown anymore, because they caused troubles when crafting the final proceedings
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ This is the official version of the class “lni” for submissions to the
 
 It is based on previous templates created on behalf of the GI.
 
-Quick start:
+## Quick start
+
 Download [`lni-author-template.tex`](lni-author-template.tex) and edit it in
 your favorite LaTeX editor.
-By default [BibTeX](https://www.ctan.org/pkg/bibtex) is used as bibliography tool.
+By default, [BibTeX](https://www.ctan.org/pkg/bibtex) is used as bibliography tool.
 In case you want to use [biblatex](https://www.ctan.org/pkg/biblatex) together with
 [Biber](https://www.ctan.org/pkg/biber) (strongly recommended), read on in the
 documentation. There is a specialized package
@@ -31,8 +32,10 @@ option. See documentation for details.
 
 You should use `pdflatex` as `xelatex` and `lualatex` lack some features of the class file.
 
+## More information
+
 Stable versions are always uploaded to CTAN and available at <https://www.ctan.org/pkg/lni>.
-In addition, you will find the most recent developer version on GitHub at https://github.com/gi-ev/lni.
+In addition, you will find the most recent developer version on GitHub at <https://github.com/gi-ev/lni>.
 The most recent documentation is available at <https://gi-ev.github.io/LNI/lni.pdf>.
 It includes a short description how to use the template and also provides troubleshooting hints.
 

--- a/lni.cls
+++ b/lni.cls
@@ -56,7 +56,9 @@
 \newif\ifautofonts
 \autofontstrue
 \newif\ifnorunningheads
+\norunningheadstrue
 \DeclareOption{norunningheads}{\norunningheadstrue}
+\DeclareOption{runningheads}{\norunningheadsfalse}
 \newif\ifanonymous
 \anonymousfalse
 \DeclareOption{anonymous}{\anonymoustrue}

--- a/lni.dtx
+++ b/lni.dtx
@@ -328,11 +328,9 @@ This work consists of the file  lni.dtx
 % \maketitle
 %
 % \begin{abstract}
-% \noindent After several years the \lni{} bundle has been updated. The
-% resulting new version fixes some long-standing bugs, solves problems and
-% supports modern packages like \pkg{biblatex} and \pkg{microtype}. It has been
-% put into one DTX file to make maintaining and distributing via CTAN a bit
-% easier.
+% \noindent This class is supporting typesetting papers for the Lecture
+% Notes in Compuer Science. It is maintained on GitHub. Feel free to
+% suggest improvements there.
 % \end{abstract}
 %
 % \section{Introduction}
@@ -447,8 +445,13 @@ This work consists of the file  lni.dtx
 % to load the package \pkg{mathptmx} instead of the New TX fonts. The output
 % will be in accordance to (or at least near) the publisher's requirements.
 %
+%
+% \DescribeOption{runningheads\space(new in v1.8)}Adds all running headers to
+% your document. This comes handy if you want to share a preprint of the paper.
+%
 % \DescribeOption{norunningheads\space(new in v1.5)}To easily remove all running
 % headers from your document, you can use the option \opt{norunningheads}.
+% As default, this option is active to easy typesetting proceedings.
 %
 % \DescribeOption{anonymous\space(new in v1.X)}To easily anonymize a paper for
 % blind review, use this option. Then all author information will be replaced
@@ -726,7 +729,7 @@ This work consists of the file  lni.dtx
 % \section{Trouble shooting}
 % This section lists the most common issues when using this template. For more
 % help, please head to
-% \href{https://github.com/egeerardyn/awesome-LaTeX/blob/master/README.md}%
+% \href{https://github.com/egeerardyn/awesome-LaTeX/tree/master#awesome-latex--}%
 % {the awesome \LaTeX{} list}.
 %
 % \begin{itemize}
@@ -813,7 +816,9 @@ This work consists of the file  lni.dtx
 \newif\ifautofonts
 \autofontstrue
 \newif\ifnorunningheads
+\norunningheadstrue
 \DeclareOption{norunningheads}{\norunningheadstrue}
+\DeclareOption{runningheads}{\norunningheadsfalse}
 \newif\ifanonymous
 \anonymousfalse
 \DeclareOption{anonymous}{\anonymoustrue}

--- a/lni.ins
+++ b/lni.ins
@@ -13,7 +13,7 @@
 \declarepreamble\bibtexengpre
 lnig.bst
 Lecture Notes in Informatics Style File (english)
-Version 1.0 (2017/04/07)
+Version 1.1 (2022/06/10)
 
 The Style File is based on alpha.bst
 
@@ -25,7 +25,7 @@ Modified files should be clearly indicated as such and renamed.
 \declarepreamble\bibtexgerpre
 lnig.bst
 Lecture Notes in Informatics Style File (german)
-Version 1.0 (2017/04/07)
+Version 1.1 (2022/06/10)
 
 The Style File is based on alpha.bst
 
@@ -57,7 +57,7 @@ License:| Released under the LaTeX Project Public License v1.3c or later
 
 \postamble
 
-Copyright (C) 2016-2021 by Gesellschaft für Informatik e.V. (GI)
+Copyright (C) 2016-2023 by Gesellschaft für Informatik e.V. (GI)
 
 This work may be distributed and/or modified under the
 conditions of the LaTeX Project Public License (LPPL), either
@@ -96,19 +96,19 @@ This work consists of the file  lni.dtx
   \file{lnig.bst}{\from{\jobname.dtx}{bibtex,ger}}
 }
 \endbatchfile
-%% 
+%%
 %% Copyright (C) 2016-2021 by Gesellschaft für Informatik e.V. (GI)
-%% 
+%%
 %% This work may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License (LPPL), either
 %% version 1.3c of this license or (at your option) any later
 %% version.  The latest version of this license is in the file:
-%% 
+%%
 %% http://www.latex-project.org/lppl.txt
-%% 
+%%
 %% This work is "maintained" (as per LPPL maintenance status) by
 %% Martin Sievers.
-%% 
+%%
 %% This work consists of the file  lni.dtx
 %%                                 lni.ins
 %%                                 README.md


### PR DESCRIPTION
This refs https://github.com/gi-ev/LNI/issues/94

No more running heads as default, because GI e.V. removed it from the Word template.

- Add "runningheads" as class option and make "norunningheads" default
- Add pdflatex lni.ins to check
- Update copyrright years in lni.ins
- lni.pdf: Refine abstract, refine link to awesome-latex
