### PR TITLE
Add tests based on MWEs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,6 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        fail-fast: false
         engine: [pdflatex, lualatex]
         lang: [en, de]
     defaults:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,8 +101,8 @@ jobs:
     name: Test MWEs
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         engine: [pdflatex, lualatex]
         lang: [en, de]
     defaults:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
       - run: biber lni-paper-example-de
       - run: ${{ matrix.engine }} lni-paper-example-de
       - run: ${{ matrix.engine }} lni-paper-example-de
-      - run: texlogsieve lni-paper-example-de.log      
+      - run: texlogsieve lni-paper-example-de.log
 
       - name: Upload build result
         uses: actions/upload-artifact@v3
@@ -97,6 +97,28 @@ jobs:
         with:
           name: CTAN-${{ matrix.engine }}
           path: '*.tar.gz'
+  tests:
+    name: Test MWEs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        engine: [pdflatex, lualatex]
+        lang: [en, de]
+    defaults:
+      run:
+        working-directory: ./tests
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          show-progress: ''
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v3
+        with:
+           package_file: Texlivefile
+      - run: ${{ matrix.engine }} mwe-biblatex--${{ matrix.lang }}
+      - run: biber mwe-biblatex--${{ matrix.lang }}
+      - run: ${{ matrix.engine }} mwe-biblatex--${{ matrix.lang }}
   changelog:
     name: CHANGELOG.md
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,6 +117,8 @@ jobs:
         uses: zauguin/install-texlive@v3
         with:
            package_file: Texlivefile
+      - name: Make lni.cls available
+        run: cp ../lni.cls .
       - run: ${{ matrix.engine }} mwe-biblatex-${{ matrix.lang }}
       - run: biber mwe-biblatex--${{ matrix.lang }}
       - run: ${{ matrix.engine }} mwe-biblatex-${{ matrix.lang }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,9 +117,9 @@ jobs:
         uses: zauguin/install-texlive@v3
         with:
            package_file: Texlivefile
-      - run: ${{ matrix.engine }} mwe-biblatex--${{ matrix.lang }}
+      - run: ${{ matrix.engine }} mwe-biblatex-${{ matrix.lang }}
       - run: biber mwe-biblatex--${{ matrix.lang }}
-      - run: ${{ matrix.engine }} mwe-biblatex--${{ matrix.lang }}
+      - run: ${{ matrix.engine }} mwe-biblatex-${{ matrix.lang }}
   changelog:
     name: CHANGELOG.md
     runs-on: ubuntu-latest

--- a/tests/mwe-biblatex-de.tex
+++ b/tests/mwe-biblatex-de.tex
@@ -1,5 +1,5 @@
 \documentclass[biblatex]{lni}
-\bibliography{mwe.bib}
+\addbibresource{mwe.bib}
 \begin{document}
 \title{Titel}
 \author{Vorname Nachname}

--- a/tests/mwe-biblatex-de.tex
+++ b/tests/mwe-biblatex-de.tex
@@ -1,0 +1,13 @@
+\documentclass[biblatex]{lni}
+\bibliography{mwe.bib}
+\begin{document}
+\title{Titel}
+\author{Vorname Nachname}
+\maketitle
+\begin{abstract}
+Text
+\end{abstract}
+\section{Einleitung}
+Text~\cite{jabref}.
+\printbibliography
+\end{document}

--- a/tests/mwe-biblatex-de.tex
+++ b/tests/mwe-biblatex-de.tex
@@ -1,5 +1,5 @@
 \documentclass[biblatex]{lni}
-\addbibresource{mwe.bib}
+\bibliography{mwe.bib}
 \begin{document}
 \title{Titel}
 \author{Vorname Nachname}

--- a/tests/mwe-biblatex-en.tex
+++ b/tests/mwe-biblatex-en.tex
@@ -1,5 +1,5 @@
 \documentclass[biblatex,english]{lni}
-\addbibresource{mwe.bib}
+\bibliography{mwe.bib}
 \begin{document}
 \title{Title}
 \author{Firstname Lastname}

--- a/tests/mwe-biblatex-en.tex
+++ b/tests/mwe-biblatex-en.tex
@@ -1,0 +1,13 @@
+\documentclass[biblatex,english]{lni}
+\bibliography{mwe.bib}
+\begin{document}
+\title{Title}
+\author{Firstname Lastname}
+\maketitle
+\begin{abstract}
+Text
+\end{abstract}
+\section{Introduction}
+Text~\cite{jabref}.
+\printbibliography
+\end{document}

--- a/tests/mwe-biblatex-en.tex
+++ b/tests/mwe-biblatex-en.tex
@@ -1,5 +1,5 @@
 \documentclass[biblatex,english]{lni}
-\bibliography{mwe.bib}
+\addbibresource{mwe.bib}
 \begin{document}
 \title{Title}
 \author{Firstname Lastname}

--- a/tests/mwe.bib
+++ b/tests/mwe.bib
@@ -10,4 +10,3 @@
   doi     = {10.47397/tb/44-3/tb138kopp-jabref},
   year    = {2023},
 }
-

--- a/tests/mwe.bib
+++ b/tests/mwe.bib
@@ -1,0 +1,13 @@
+@Article{jabref,
+  author  = {Oliver Kopp and Carl Christian Snethlage and Christoph Schwentker},
+  title   = {JabRef: BibTeX-based literature management software},
+  journal = {TUGboat},
+  issn    = {0896-3207},
+  issue   = {138},
+  volume  = {44},
+  number  = {3},
+  pages   = {441--447},
+  doi     = {10.47397/tb/44-3/tb138kopp-jabref},
+  year    = {2023},
+}
+


### PR DESCRIPTION
At https://github.com/gi-ev/biblatex-lni/pull/29, I got a strange error.

```
! LaTeX Error: \begin{document} ended by \end{abstract}.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.9 \end{abstract}
                  
? 
! Emergency stop.
 ...                                              
                                                  
l.9 \end{abstract}
                  
!  ==> Fatal error occurred, no output PDF file produced!
```

This PR ports the MWE to this repository to a) enable tracking the issue b) bringing MWEs to this repo.